### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/wechat/requirements.txt
+++ b/wechat/requirements.txt
@@ -11,7 +11,7 @@ python-dateutil==2.7.3
 python-mimeparse==1.6.0
 requests==2.18.4
 six==1.11.0
-urllib3==1.22
+urllib3==1.26.5
 waitress==1.1.0
 wechatpy==1.7.0
 xmltodict==0.11.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.22
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.22 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS